### PR TITLE
chore: use pydantic config dict

### DIFF
--- a/nanobot/config/schema.py
+++ b/nanobot/config/schema.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic_settings import BaseSettings
 
 
@@ -258,6 +258,8 @@ class ToolsConfig(BaseModel):
 class Config(BaseSettings):
     """Root configuration for nanobot."""
 
+    model_config = ConfigDict(env_prefix="NANOBOT_", env_nested_delimiter="__")
+
     agents: AgentsConfig = Field(default_factory=AgentsConfig)
     channels: ChannelsConfig = Field(default_factory=ChannelsConfig)
     providers: ProvidersConfig = Field(default_factory=ProvidersConfig)
@@ -321,7 +323,3 @@ class Config(BaseSettings):
             if spec and spec.is_gateway and spec.default_api_base:
                 return spec.default_api_base
         return None
-
-    class Config:
-        env_prefix = "NANOBOT_"
-        env_nested_delimiter = "__"


### PR DESCRIPTION
## Summary
- replace deprecated class-based Pydantic settings config with ConfigDict
- keep env prefix and nested delimiter behavior unchanged

## Testing
- uv run pytest